### PR TITLE
Hack - Add RDEPENDS wayland-default-egl in vendor packages

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,4 +22,5 @@ BBFILES += "${LAYERDIR}/meta-rdk-oss-reference/recipes-multimedia/gstreamer/gstr
             ${LAYERDIR}/recipes-graphics/cairo/cairo_%.bbappend \
             ${LAYERDIR}/meta-rdk-oss-reference/recipes-kernel/make-mod-scripts/*.bb \
             ${LAYERDIR}/meta-rdk-oss-reference/recipes-kernel/make-mod-scripts/*.bbappend \
+            ${LAYERDIR}/recipes-graphics/mesa/mesa_%.bbappend \
             "

--- a/recipes-workaround/cairo/cairo_%.bbappend
+++ b/recipes-workaround/cairo/cairo_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/cairo/cairo_%.bbappend
+++ b/recipes-workaround/cairo/cairo_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/devicesettings/devicesettings-hal-raspberrypi4_%.bbappend
+++ b/recipes-workaround/devicesettings/devicesettings-hal-raspberrypi4_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/devicesettings/devicesettings-hal-raspberrypi4_%.bbappend
+++ b/recipes-workaround/devicesettings/devicesettings-hal-raspberrypi4_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-libav_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-libav_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-libav_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-libav_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/libepoxy/libepoxy_%.bbappend
+++ b/recipes-workaround/libepoxy/libepoxy_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/libepoxy/libepoxy_%.bbappend
+++ b/recipes-workaround/libepoxy/libepoxy_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/librsvg/librsvg_%.bbappend
+++ b/recipes-workaround/librsvg/librsvg_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/librsvg/librsvg_%.bbappend
+++ b/recipes-workaround/librsvg/librsvg_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/pango/pango_%.bbappend
+++ b/recipes-workaround/pango/pango_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/pango/pango_%.bbappend
+++ b/recipes-workaround/pango/pango_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/userland/userland_git.bbappend
+++ b/recipes-workaround/userland/userland_git.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/userland/userland_git.bbappend
+++ b/recipes-workaround/userland/userland_git.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/wayland/wayland_%.bbappend
+++ b/recipes-workaround/wayland/wayland_%.bbappend
@@ -1,0 +1,4 @@
+# Only works with OSS release 3.0.3 since the wayland.bbappend
+# was customized to provide wayland-default-egl from OSS.
+
+RDEPENDS_${PN}-dev += "${PN}-default-egl-dev"

--- a/recipes-workaround/westeros/essos.bbappend
+++ b/recipes-workaround/westeros/essos.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/essos.bbappend
+++ b/recipes-workaround/westeros/essos.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-simplebuffer.bbappend
+++ b/recipes-workaround/westeros/westeros-simplebuffer.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-simplebuffer.bbappend
+++ b/recipes-workaround/westeros/westeros-simplebuffer.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-simpleshell.bbappend
+++ b/recipes-workaround/westeros/westeros-simpleshell.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-simpleshell.bbappend
+++ b/recipes-workaround/westeros/westeros-simpleshell.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-sink.bbappend
+++ b/recipes-workaround/westeros/westeros-sink.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-sink.bbappend
+++ b/recipes-workaround/westeros/westeros-sink.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-soc-drm.bbappend
+++ b/recipes-workaround/westeros/westeros-soc-drm.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-soc-drm.bbappend
+++ b/recipes-workaround/westeros/westeros-soc-drm.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros.bbappend
+++ b/recipes-workaround/westeros/westeros.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS += "wayland-default-egl"
+RDEPENDS_${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros.bbappend
+++ b/recipes-workaround/westeros/westeros.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS += "wayland-default-egl"


### PR DESCRIPTION
This is a hack/work-around until OSS team fixes the wayland issue.