### PR TITLE
Clean-up to match the wayland-egl optimization

### DIFF
--- a/recipes-workaround/cairo/cairo_%.bbappend
+++ b/recipes-workaround/cairo/cairo_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/devicesettings/devicesettings-hal-raspberrypi4_%.bbappend
+++ b/recipes-workaround/devicesettings/devicesettings-hal-raspberrypi4_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-libav_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-libav_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-workaround/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/libepoxy/libepoxy_%.bbappend
+++ b/recipes-workaround/libepoxy/libepoxy_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/librsvg/librsvg_%.bbappend
+++ b/recipes-workaround/librsvg/librsvg_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/pango/pango_%.bbappend
+++ b/recipes-workaround/pango/pango_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/userland/userland_git.bbappend
+++ b/recipes-workaround/userland/userland_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/essos.bbappend
+++ b/recipes-workaround/westeros/essos.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-simplebuffer.bbappend
+++ b/recipes-workaround/westeros/westeros-simplebuffer.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-simpleshell.bbappend
+++ b/recipes-workaround/westeros/westeros-simpleshell.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-sink.bbappend
+++ b/recipes-workaround/westeros/westeros-sink.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"

--- a/recipes-workaround/westeros/westeros-soc-drm.bbappend
+++ b/recipes-workaround/westeros/westeros-soc-drm.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN} += "wayland-default-egl"


### PR DESCRIPTION
Bring-in the missing changes of https://github.com/rdkcentral/meta-oss-vendor-raspberrypi/commit/550dbadde2da04644a8a0531dd56654802a3947a