### PR TITLE
REFPLTV-2609: Audio not heard for AC3 and EAC3 streams

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,6 +23,7 @@ BBFILES += "${LAYERDIR}/meta-rdk-oss-reference/recipes-multimedia/gstreamer/gstr
             ${LAYERDIR}/meta-rdk-oss-reference/recipes-kernel/make-mod-scripts/*.bb \
             ${LAYERDIR}/meta-rdk-oss-reference/recipes-kernel/make-mod-scripts/*.bbappend \
             ${LAYERDIR}/recipes-graphics/mesa/mesa_%.bbappend \
+            ${LAYERDIR}/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend \
             "
 
 # OSS layer is customising wayland and removing wayland-egl.so and PC file causing build errors.

--- a/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
+++ b/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
@@ -1,0 +1,4 @@
+EXTRA_OECONF:append = " \
+    --enable-decoder=ac3 \
+    --enable-decoder=eac3 \
+"


### PR DESCRIPTION
Reason for change: Enabling ac3 decoders in ffmpeg Test Procedure: Play ac3 streams using gst launch
Risks:High
Priority: P1