### PR TITLE
REFPLTV-2596: RDKServices : Some of the plugin APIs are not returning…

### DIFF
--- a/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
+++ b/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
@@ -2,3 +2,4 @@ EXTRA_OECONF:append = " \
     --enable-decoder=ac3 \
     --enable-decoder=eac3 \
 "
+EXTRA_OECONF:remove = "--disable-everything"


### PR DESCRIPTION
… the proper response

Reason for change: Removing disable everything in ffmpeg Test Procedure: Check output of PlayerInfo.videocodecs and see all required codecs are listing Risks:High
Priority: P1