### PR TITLE
RDKECOREMW-395: libdrm fails to compile with stack layering 3.0.0

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -32,4 +32,5 @@ BBFILES += " \
             ${LAYERDIR}/recipes-graphics/mesa/mesa_%.bbappend \
             ${LAYERDIR}/recipes-workaround/westeros/westeros.bbappend \
             ${LAYERDIR}/recipes-workaround/gstreamer/gstreamer1.0-plugins-base_%.bbappend \
+            ${LAYERDIR}/recipes-workaround/drm/libdrm_2.4.110.bbappend \
             "

--- a/recipes-workaround/drm/libdrm_2.4.110.bbappend
+++ b/recipes-workaround/drm/libdrm_2.4.110.bbappend
@@ -1,0 +1,3 @@
+# Todo: Remove on consuming OSS change (https://github.com/rdkcentral/meta-rdk-oss-reference/pull/153)
+# To support Ipk consumption
+RPROVIDES:${PN} = "drm"


### PR DESCRIPTION
Reason for change: MW component depends on drm which is provided by libdrm (vendor arch). MW is building libdrm as it is not able to resolve dependency for drm in ipk consumption model.