### PR TITLE
REFPLTV-3098: Observing visible slowness For Installed Apps including YouTube.

### DIFF
--- a/recipes-graphics/westeros/files/0001-REFPLTV-3098-Apps-Slowness-issue-fix.patch
+++ b/recipes-graphics/westeros/files/0001-REFPLTV-3098-Apps-Slowness-issue-fix.patch
@@ -1,0 +1,30 @@
+Index: git/westeros-render-embedded.cpp
+===================================================================
+--- git.orig/westeros-render-embedded.cpp
++++ git/westeros-render-embedded.cpp
+@@ -544,7 +544,24 @@ static WstRendererEMB* wstRendererEMBCre
+             if ( rendererEMB->eglBindWaylandDisplayWL &&
+                  rendererEMB->eglUnbindWaylandDisplayWL &&
+                  rendererEMB->eglQueryWaylandBufferWL )
+-            {               
++            {
++#ifdef WESTEROS_PLATFORM_EMBEDDED_RPI
++               printf("calling eglUnbindWaylandDisplayWL with eglDisplay %p and wayland display %p before bind\n", rendererEMB->eglDisplay, renderer->display );
++               EGLBoolean unbindRc= rendererEMB->eglUnbindWaylandDisplayWL( rendererEMB->eglDisplay, renderer->display );
++
++               if ( unbindRc ) {
++                  printf("pre-bind eglUnbindWaylandDisplayWL succeeded\n" );
++               }
++               else {
++                  EGLint unbindErr= eglGetError();
++
++                  if ( unbindErr == EGL_SUCCESS )
++                     printf("pre-bind eglUnbindWaylandDisplayWL returned false with EGL_SUCCESS (nothing to unbind)\n" );
++                  else
++                     printf("pre-bind eglUnbindWaylandDisplayWL failed: %x (continuing)\n", unbindErr );
++               }
++#endif /* WESTEROS_PLATFORM_EMBEDDED_RPI */
++
+                printf("calling eglBindWaylandDisplayWL with eglDisplay %p and wayland display %p\n", rendererEMB->eglDisplay, renderer->display );
+                EGLBoolean rc= rendererEMB->eglBindWaylandDisplayWL( rendererEMB->eglDisplay, renderer->display );
+                if ( rc )

--- a/recipes-graphics/westeros/westeros.bbappend
+++ b/recipes-graphics/westeros/westeros.bbappend
@@ -1,6 +1,12 @@
 # bbappend for raspberryPi
 #
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# REFPLTV-3098-Apps-Slowness-issue-fix Patch file, need to remove this patch when following CL changes available in next tag release version of westeros.
+# https://code.rdkcentral.com/r/c/components/opensource/westeros/+/125960 -> Change CL in Westeros.
+SRC_URI += "file://0001-REFPLTV-3098-Apps-Slowness-issue-fix.patch"
+
 PACKAGECONFIG = "incapp inctest increndergl incsbprotocol xdgv4"
 PACKAGECONFIG:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'modules', '', d)}"
 
@@ -11,6 +17,7 @@ PACKAGECONFIG[inclexpsyncprotocol] = "--enable-lexpsyncprotocol=yes"
 
 CXXFLAGS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '-DWESTEROS_PLATFORM_DRM', '-DWESTEROS_PLATFORM_RPI -DWESTEROS_INVERTED_Y -DBUILD_WAYLAND -I${STAGING_INCDIR}/interface/vmcs_host/linux', d)} "
 CXXFLAGS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '-DUSE_MESA', '', d)}"
+CXXFLAGS:append = " -DWESTEROS_PLATFORM_EMBEDDED_RPI"
 
 inherit systemd update-rc.d
 


### PR DESCRIPTION
**Reason for change:** Added the patch file for slowness issue fix and enable the -DFlag for patch file changes. 
**Patch Update Reason:**
eglBindWaylandDisplayWL() call get's failed on Second Window display application, But not seen in First Window. Becauae We have used the Same EGL display on each application window, but application uses the different Wayland Displays.

When eglBindWaylandDisplayWL() Triggers, following condition gets failed on libEGL.so library on Second Window Applications only. dri2_bind_wayland_display_wl(_EGLDisplay *disp, struct wl_display *wl_dpy) {
..
struct dri2_egl_display *dri2_dpy = dri2_egl_display(disp);
   if (dri2_dpy->wl_server_drm) {
      return EGL_FALSE;
   }
..
}

Previous window details gets stored in wl_server_drm pointer. So, now we use the unbind call to Clear the wl_server_drm pointer, to success the eglBindWaylandDisplayWL() call for current wayland display.

**Test Procedure:** Build and verify.
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com