### PR TITLE
REFPLTV-3098: Observing visible slowness For Installed Apps including YouTube.

### DIFF
--- a/recipes-graphics/westeros/westeros.bbappend
+++ b/recipes-graphics/westeros/westeros.bbappend
@@ -11,6 +11,7 @@ PACKAGECONFIG[inclexpsyncprotocol] = "--enable-lexpsyncprotocol=yes"
 
 CXXFLAGS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '-DWESTEROS_PLATFORM_DRM', '-DWESTEROS_PLATFORM_RPI -DWESTEROS_INVERTED_Y -DBUILD_WAYLAND -I${STAGING_INCDIR}/interface/vmcs_host/linux', d)} "
 CXXFLAGS:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '-DUSE_MESA', '', d)}"
+CXXFLAGS:append = " -DWESTEROS_PLATFORM_EMBEDDED_RPI"
 
 inherit systemd update-rc.d
 


### PR DESCRIPTION
Reason for change: Added the -DFlag WESTEROS_PLATFORM_EMBEDDED_RPI for App slowness issue fix.
Test Procedure: Build and verify.
Risks: High.
Signed-off-by: sundaramuneeswaran_muthuraj@comcast.com