### PR TITLE
RDKEVL-6491: Phase1[RPI] Vendor layer changes expected for westeros refactoring

### DIFF
--- a/recipes-graphics/westeros/files/0001-westeros-sink-1080p.patch
+++ b/recipes-graphics/westeros/files/0001-westeros-sink-1080p.patch
@@ -9,10 +9,10 @@ Source: COMCAST
 Upstream-Status: Pending
 Signed-off-by: jwanna001 <jeff_wannamaker@cable.comcast.com>
 ---
-Index: git/westeros-sink/westeros-sink.h
+Index: git/westeros-sink.h
 ===================================================================
---- git.orig/westeros-sink/westeros-sink.h
-+++ git/westeros-sink/westeros-sink.h
+--- git.orig/westeros-sink.h
++++ git/westeros-sink.h
 @@ -28,8 +28,13 @@
 
  #define DEFAULT_WINDOW_X (0)

--- a/recipes-graphics/westeros/westeros-sink.bb
+++ b/recipes-graphics/westeros/westeros-sink.bb
@@ -4,9 +4,15 @@ SUMMARY = "This receipe compiles the westeros compositor gstreamer sink element"
 
 LICENSE = "LGPLv2.1"
 
-S = "${WORKDIR}/git/westeros-sink"
+S = "${WORKDIR}/git"
 
-LICENSE_LOCATION = "${S}/../LICENSE"
+SRC_URI = "${WESTEROS_SINK_URI}"
+SRCREV_FORMAT = "westeros-sink"
+
+LICENSE_LOCATION = "${S}/LICENSE"
+LIC_FILES_CHKSUM = "file://${LICENSE_LOCATION};md5=8fb65319802b0c15fc9e0835350ffa02"
+
+PSEUDO_IGNORE_PATHS .= ",${WORKDIR}/git"
 
 inherit autotools pkgconfig
 

--- a/recipes-graphics/westeros/westeros.bbappend
+++ b/recipes-graphics/westeros/westeros.bbappend
@@ -17,7 +17,8 @@ inherit systemd update-rc.d
 CXXFLAGS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_ermgr', ' -DUSE_ESSRMGR_UDS_IMPL', '', d)}"
 
 do_configure:prepend () {
-    sed -i -e 's/-lwesteros_simplebuffer_client/-lwesteros_compositor -lwesteros_simplebuffer_client/g' ${S}/rpi/westeros-sink/Makefile.am
+#    sed -i -e 's/-lwesteros_simplebuffer_client/-lwesteros_compositor -lwesteros_simplebuffer_client/g' ${S}/rpi/westeros-sink/Makefile.am
+    sed -i -e 's/-lwesteros_simplebuffer_client/-lwesteros_compositor -lwesteros_simplebuffer_client/g' ${S}/Makefile.am
 }
 
 do_compile:prepend () {


### PR DESCRIPTION
Reason for change:  westeros refactoring where westeros is split into 5 different repositories

Test Procedure: Build and verify

Risks: Low